### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/RabbitMQ.Bus.Autofac/RabbitMQ.Bus.Autofac.csproj
+++ b/src/RabbitMQ.Bus.Autofac/RabbitMQ.Bus.Autofac.csproj
@@ -14,7 +14,15 @@
     <RepositoryUrl>https://github.com/ojdev/RabbitMQ.Bus</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageTags>rqbbitmq,dnc,autofac</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard2.0\RabbitMQ.Bus.Autofac.xml</DocumentationFile>

--- a/src/RabbitMQ.Bus/RabbitMQ.Bus.csproj
+++ b/src/RabbitMQ.Bus/RabbitMQ.Bus.csproj
@@ -14,7 +14,15 @@
     <Version>1.0.6</Version>
     <RepositoryType>github</RepositoryType>
     <PackageIconUrl>https://raw.githubusercontent.com/ojdev/RabbitMQ.Bus/master/rabbitmq.bus.png</PackageIconUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard2.0\RabbitMQ.Bus.xml</DocumentationFile>

--- a/src/RabbitMQ.EventBus.AspNetCore.Butterfly/RabbitMQ.EventBus.AspNetCore.Butterfly.csproj
+++ b/src/RabbitMQ.EventBus.AspNetCore.Butterfly/RabbitMQ.EventBus.AspNetCore.Butterfly.csproj
@@ -13,7 +13,15 @@
     <PackageTags>rqbbitmq,dnc,eventbus,butterfly</PackageTags>
     <Description>RabbitMQ.EventBus.AspNetCore.Butterfly</Description>
     <Version>1.0.2</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Housecool.Butterfly.Client.AspNetCore" Version="0.0.11" />

--- a/src/RabbitMQ.EventBus.AspNetCore/RabbitMQ.EventBus.AspNetCore.csproj
+++ b/src/RabbitMQ.EventBus.AspNetCore/RabbitMQ.EventBus.AspNetCore.csproj
@@ -13,7 +13,15 @@
     <PackageLicenseUrl>https://github.com/ojdev/RabbitMQ.Bus/raw/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ojdev/RabbitMQ.Bus</PackageProjectUrl>
     <Version>1.1.2</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\RabbitMQ.EventBus.AspNetCore.xml</DocumentationFile>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
